### PR TITLE
[Triple-Barrier-Method] Add configuration manager with YAML support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+.mypy_cache/
+.pytest_cache/
+Logs/

--- a/ConfigManager.py
+++ b/ConfigManager.py
@@ -1,0 +1,33 @@
+import logging
+from pathlib import Path
+from typing import Any, Dict
+
+import yaml  # type: ignore
+
+
+class ConfigManager:
+    """Handle loading and saving of YAML configuration files."""
+
+    def __init__(self, FilePath: str) -> None:
+        self.FilePath = Path(FilePath)
+        if not self.FilePath.exists():
+            logging.getLogger(__name__).info(
+                "Configuration file %s not found. Creating with empty dict.",
+                self.FilePath,
+            )
+            self.SaveParams({})
+
+    def LoadParams(self) -> Dict[str, Any]:
+        """Load parameters from YAML file."""
+        if not self.FilePath.exists():
+            return {}
+        with self.FilePath.open("r", encoding="utf-8") as File:
+            Data = yaml.safe_load(File) or {}
+        return Data
+
+    def SaveParams(self, Params: Dict[str, Any]) -> None:
+        """Save parameters to YAML file, overwriting existing entries."""
+        Existing = self.LoadParams()
+        Existing.update(Params)
+        with self.FilePath.open("w", encoding="utf-8") as File:
+            yaml.safe_dump(Existing, File)

--- a/Params.yaml
+++ b/Params.yaml
@@ -1,0 +1,5 @@
+EndDate: '2023-01-10'
+Interval: 1d
+LastDownloadedRows: 5
+StartDate: '2023-01-01'
+Ticker: AAPL

--- a/UnitTests/test_config_manager.py
+++ b/UnitTests/test_config_manager.py
@@ -1,0 +1,24 @@
+import sys
+from pathlib import Path
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+import yaml  # type: ignore
+
+from ConfigManager import ConfigManager
+
+
+def test_load_and_save_params(tmp_path: Path) -> None:
+    File = tmp_path / "config.yaml"
+    Manager = ConfigManager(str(File))
+    Manager.SaveParams({"Key": "Value"})
+    Params = Manager.LoadParams()
+    assert Params["Key"] == "Value"
+
+
+def test_overwrite_params(tmp_path: Path) -> None:
+    File = tmp_path / "config.yaml"
+    Manager = ConfigManager(str(File))
+    Manager.SaveParams({"A": 1})
+    Manager.SaveParams({"A": 2, "B": 3})
+    with File.open("r", encoding="utf-8") as FH:
+        Data = yaml.safe_load(FH)
+    assert Data == {"A": 2, "B": 3}

--- a/main.py
+++ b/main.py
@@ -1,0 +1,42 @@
+import logging
+from logging.handlers import RotatingFileHandler
+from pathlib import Path
+
+from ConfigManager import ConfigManager
+from DataDownloader import YFinanceDownloader
+
+
+def SetupLogging() -> None:
+    LogsDir = Path("Logs")
+    LogsDir.mkdir(exist_ok=True)
+    Handler = RotatingFileHandler(
+        LogsDir / "app.log",
+        maxBytes=1024 * 1024,
+        backupCount=3,
+    )
+    LoggingFormat = "%(asctime)s - %(levelname)s - %(message)s"
+    logging.basicConfig(level=logging.INFO, handlers=[Handler], format=LoggingFormat)
+
+
+def main() -> None:
+    SetupLogging()
+    Manager = ConfigManager("Params.yaml")
+    Params = Manager.LoadParams()
+    logging.info("Loaded parameters: %s", Params)
+
+    Downloader = YFinanceDownloader(
+        Params.get("Ticker", "AAPL"),
+        Params.get("StartDate", "2023-01-01"),
+        Params.get("EndDate", "2023-01-10"),
+        Params.get("Interval", "1d"),
+    )
+
+    Data = Downloader.DownloadData()
+    logging.info("Downloaded %d rows", len(Data))
+
+    Manager.SaveParams({"LastDownloadedRows": int(len(Data))})
+    logging.info("Updated parameters saved to Params.yaml")
+
+
+if __name__ == "__main__":
+    main()

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,2 @@
+[mypy]
+ignore_missing_imports = True


### PR DESCRIPTION
## Summary
- add ConfigManager for YAML params
- update main entrypoint to use configuration
- save runtime data back into params
- add Params.yaml defaults
- add mypy config and gitignore
- add unit tests