### PR TITLE
[Triple-Barrier-Method] Add generic labeling and Triple Barrier implementation

### DIFF
--- a/DataLabel.py
+++ b/DataLabel.py
@@ -1,0 +1,64 @@
+import logging
+from typing import Any, Callable, Dict, Tuple
+
+import pandas as pd
+
+
+class DataLabel:
+    """Generic labeling utilities for trading data."""
+
+    def __init__(self, Params: Dict[str, Any]) -> None:
+        self.Params = Params
+        self.Methods: Dict[str, Callable[[pd.DataFrame], pd.DataFrame]] = {}
+        self.RegisterMethod("TripleBarrier", self.TripleBarrier)
+
+    def RegisterMethod(self, Name: str, Func: Callable[[pd.DataFrame], pd.DataFrame]) -> None:
+        """Register a new labeling method."""
+        self.Methods[Name] = Func
+
+    def Apply(self, Name: str, Data: pd.DataFrame) -> pd.DataFrame:
+        """Apply a registered labeling method to Data."""
+        if Name not in self.Methods:
+            raise ValueError(f"Method {Name} not registered")
+        return self.Methods[Name](Data)
+
+    def CalculateUpDownVolatility(self, Prices: pd.Series) -> Tuple[pd.Series, pd.Series]:
+        """Return EWMA up and down volatilities."""
+        Span = int(self.Params.get("VolatilitySpan", 20))
+        Returns = Prices.pct_change()
+        UpVol = Returns.where(Returns > 0).ewm(span=Span, adjust=False).std()
+        DownVol = Returns.where(Returns < 0).abs().ewm(span=Span, adjust=False).std()
+        UpVol = UpVol.fillna(0)
+        DownVol = DownVol.fillna(0)
+        return UpVol, DownVol
+
+    def TripleBarrier(self, Data: pd.DataFrame) -> pd.DataFrame:
+        """Label data using the Triple Barrier Method."""
+        if "Close" not in Data.columns:
+            raise ValueError("Data must contain a Close column")
+        Data = Data.copy()
+        UpVol, DownVol = self.CalculateUpDownVolatility(Data["Close"])
+        TpMult = float(self.Params.get("TakeProfitMultiplier", 1.0))
+        SlMult = float(self.Params.get("StopLossMultiplier", 1.0))
+        Barrier = int(self.Params.get("VerticalBarrier", 5))
+        Data["Label"] = 0
+        CloseCol = Data.columns.get_loc("Close")
+        LabelCol = Data.columns.get_loc("Label")
+
+        for Index in range(len(Data)):
+            Price = Data.iat[Index, CloseCol]
+            TakeProfit = Price + TpMult * UpVol.iat[Index]
+            StopLoss = Price - SlMult * DownVol.iat[Index]
+            End = min(Index + Barrier, len(Data) - 1)
+            Label = 0
+            for J in range(Index + 1, End + 1):
+                CurrentPrice = Data.iat[J, CloseCol]
+                if CurrentPrice >= TakeProfit:
+                    Label = 1
+                    break
+                if CurrentPrice <= StopLoss:
+                    Label = -1
+                    break
+            Data.iat[Index, LabelCol] = Label
+        logging.getLogger(__name__).info("Applied TripleBarrier labeling")
+        return Data

--- a/Params.yaml
+++ b/Params.yaml
@@ -2,4 +2,8 @@ EndDate: '2023-01-10'
 Interval: 1d
 LastDownloadedRows: 5
 StartDate: '2023-01-01'
+StopLossMultiplier: 1.0
+TakeProfitMultiplier: 1.0
 Ticker: AAPL
+VerticalBarrier: 5
+VolatilitySpan: 20

--- a/UnitTests/test_data_label.py
+++ b/UnitTests/test_data_label.py
@@ -1,0 +1,33 @@
+import sys
+from pathlib import Path
+import pandas as pd
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from DataLabel import DataLabel
+
+
+def test_calculate_up_down_volatility() -> None:
+    Prices = pd.Series([100, 102, 101, 103, 104], dtype=float)
+    Params = {"VolatilitySpan": 2}
+    Labeler = DataLabel(Params)
+    UpVol, DownVol = Labeler.CalculateUpDownVolatility(Prices)
+    assert len(UpVol) == len(Prices)
+    assert (UpVol >= 0).all()
+    assert (DownVol >= 0).all()
+
+
+def test_triple_barrier_label() -> None:
+    Prices = pd.Series([100, 101, 102, 103, 104, 105], dtype=float)
+    Data = pd.DataFrame({"Close": Prices})
+    Params = {
+        "VolatilitySpan": 2,
+        "TakeProfitMultiplier": 1.0,
+        "StopLossMultiplier": 1.0,
+        "VerticalBarrier": 3,
+    }
+    Labeler = DataLabel(Params)
+    Result = Labeler.Apply("TripleBarrier", Data)
+    assert "Label" in Result.columns
+    # With strictly increasing prices take profit should trigger
+    assert Result["Label"].iloc[0] == 1

--- a/main.py
+++ b/main.py
@@ -4,6 +4,7 @@ from LogManager import SetupLogging
 
 from ConfigManager import ConfigManager
 from DataDownloader import YFinanceDownloader
+from DataLabel import DataLabel
 
 
 def main() -> None:
@@ -21,6 +22,10 @@ def main() -> None:
 
     Data = Downloader.DownloadData()
     logging.info("Downloaded %d rows", len(Data))
+
+    Labeler = DataLabel(Params)
+    Data = Labeler.Apply("TripleBarrier", Data)
+    logging.info("Applied labeling. Sample:\n%s", Data.head())
 
     Manager.SaveParams({"LastDownloadedRows": int(len(Data))})
     logging.info("Updated parameters saved to Params.yaml")


### PR DESCRIPTION
## Summary
- add new `DataLabel` module with generic labeling framework
- implement Triple Barrier labeling using EWMA up/down volatility
- configure labeling parameters in `Params.yaml`
- integrate labeling in `main.py`
- add unit tests for `DataLabel`