### PR TITLE
[Triple-Barrier-Method] Add risk based triple barrier labeling

### DIFF
--- a/DataLabel.py
+++ b/DataLabel.py
@@ -1,5 +1,4 @@
-import logging
-from typing import Any, Callable, Dict, Tuple
+from typing import Any, Callable, Dict
 
 import pandas as pd
 
@@ -21,3 +20,40 @@ class DataLabel:
         if Name not in self.Methods:
             raise ValueError(f"Method {Name} not registered")
         return self.Methods[Name](Data)
+
+    def TripleBarrier(self, Data: pd.DataFrame) -> pd.DataFrame:
+        """Label data using the Triple Barrier Method with risk management."""
+        RiskPct = float(self.Params.get("RiskPct", 1)) / 100
+        RiskRewardRatio = float(self.Params.get("RiskRewardRatio", 1))
+        TimeLimit = int(self.Params.get("TimeLimit", 5))
+
+        Required = {"High", "Low", "Close"}
+        if not Required.issubset(Data.columns):
+            Missing = Required.difference(Data.columns)
+            raise ValueError(f"Missing columns required for labeling: {Missing}")
+
+        Data = Data.copy()
+        Labels = []
+        for StartIdx in range(len(Data)):
+            Price = Data.at[Data.index[StartIdx], "Close"]
+            StopLoss = Price * (1 - RiskPct)
+            TakeProfit = Price * (1 + RiskPct * RiskRewardRatio)
+            EndIdx = min(StartIdx + TimeLimit, len(Data) - 1)
+            Slice = Data.iloc[StartIdx : EndIdx + 1]
+
+            TpMask = Slice["High"] >= TakeProfit
+            SlMask = Slice["Low"] <= StopLoss
+            TpIdx = Slice.index[TpMask].min() if TpMask.any() else None
+            SlIdx = Slice.index[SlMask].min() if SlMask.any() else None
+
+            if TpIdx is not None and SlIdx is not None:
+                Label = 1 if Slice.index.get_loc(TpIdx) <= Slice.index.get_loc(SlIdx) else -1
+            elif TpIdx is not None:
+                Label = 1
+            elif SlIdx is not None:
+                Label = -1
+            else:
+                Label = 0
+            Labels.append(Label)
+        Data["Label"] = Labels
+        return Data

--- a/Params.yaml
+++ b/Params.yaml
@@ -1,5 +1,7 @@
+Ticker: AAPL
+StartDate: '2020-01-01'
 EndDate: '2023-12-31'
 Interval: 1d
 LastDownloadedRows: 1006
-StartDate: '2020-01-01'
-Ticker: AAPL
+RiskPct: 5
+RiskRewardRatio: 2

--- a/UnitTests/test_data_label.py
+++ b/UnitTests/test_data_label.py
@@ -1,0 +1,22 @@
+from pathlib import Path
+import sys
+
+import pandas as pd
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from DataLabel import DataLabel
+
+
+def test_triple_barrier_labels() -> None:
+    Params = {"RiskPct": 5, "RiskRewardRatio": 2, "TimeLimit": 5}
+    Data = pd.DataFrame(
+        {
+            "High": [105, 111, 108, 107, 109],
+            "Low": [98, 100, 101, 102, 103],
+            "Close": [100, 101, 102, 103, 104],
+        }
+    )
+    Labeler = DataLabel(Params)
+    Labeled = Labeler.Apply("TripleBarrier", Data)
+    assert list(Labeled["Label"]) == [1, 0, 0, 0, 0]

--- a/main.py
+++ b/main.py
@@ -1,7 +1,6 @@
 import logging
 
 from LogManager import SetupLogging
-
 from ConfigManager import ConfigManager
 from DataDownloader import YFinanceDownloader
 from DataLabel import DataLabel
@@ -22,6 +21,10 @@ def main() -> None:
 
     Data = Downloader.DownloadData()
     logging.info("Downloaded %d rows", len(Data))
+
+    Labeler = DataLabel(Params)
+    Labeled = Labeler.Apply("TripleBarrier", Data)
+    logging.info("Label counts: %s", Labeled["Label"].value_counts().to_dict())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- implement Triple Barrier labeling with risk-reward ratio
- make risk parameters configurable in `Params.yaml`
- wire up `DataLabel` usage in `main.py`
- add unit test for new labeling logic