### PR TITLE
[Triple-Barrier-Method] add TimeLimit param

### DIFF
--- a/Params.yaml
+++ b/Params.yaml
@@ -5,3 +5,4 @@ Interval: 1d
 LastDownloadedRows: 1006
 RiskPct: 5
 RiskRewardRatio: 2
+TimeLimit: 5

--- a/UnitTests/test_params_yaml.py
+++ b/UnitTests/test_params_yaml.py
@@ -1,0 +1,12 @@
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from ConfigManager import ConfigManager
+
+
+def test_time_limit_in_params() -> None:
+    Manager = ConfigManager("Params.yaml")
+    Params = Manager.LoadParams()
+    assert "TimeLimit" in Params


### PR DESCRIPTION
## Summary
- include `TimeLimit` configuration in `Params.yaml`
- verify that the configuration loads correctly