### PR TITLE
[Triple-Barrier-Method] Fix pandas dtype warning in MFI

### DIFF
--- a/UnitTests/test_technical_indicator.py
+++ b/UnitTests/test_technical_indicator.py
@@ -2,6 +2,7 @@ from pathlib import Path
 import sys
 
 import pandas as pd
+import warnings
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
@@ -38,3 +39,22 @@ def test_indicator_columns_exist() -> None:
         "BBL_3_2.0",
     }
     assert ExpectedCols.issubset(Result.columns)
+
+
+def test_mfi_no_dtype_warning() -> None:
+    Data = pd.DataFrame(
+        {
+            "Close": [1, 2, 3, 4, 5],
+            "High": [2, 3, 4, 5, 6],
+            "Low": [0, 1, 2, 3, 4],
+            "Volume": [100, 110, 120, 130, 140],
+        },
+        dtype="Int64",
+    )
+    Params = {"MFIWindows": [2]}
+    with warnings.catch_warnings(record=True) as WarnList:
+        warnings.simplefilter("error", FutureWarning)
+        Indicator = TechnicalIndicator(Data, Params)
+        Result = Indicator.Apply("MFI")
+    assert Result["MFI_2"].dtype == float
+    assert not WarnList


### PR DESCRIPTION
## Summary
- cast numeric columns to float on initialization
- reimplement Money Flow Index calculation to avoid pandas FutureWarning
- test that the custom MFI raises no warnings

## Testing
- `ruff check .`
- `mypy .`
- `pytest UnitTests/test_technical_indicator.py -q`
- `pytest UnitTests -q`
- `python main.py 2>&1 | tail -n 20`

------
https://chatgpt.com/codex/tasks/task_e_6858f14e9a348320982f7044069de5e2