### PR TITLE
[Triple-Barrier-Method] Support multi-ticker downloads

### DIFF
--- a/DataDownloader.py
+++ b/DataDownloader.py
@@ -1,58 +1,54 @@
-import yfinance as yf
+from typing import List
+
 import pandas as pd
+import yfinance as yf
 
 class YFinanceDownloader:
-    def __init__(self, Ticker, StartDate, EndDate, Interval):
-        self.Ticker = Ticker
+    def __init__(self, Tickers: List[str], StartDate: str, EndDate: str, Interval: str) -> None:
+        self.Tickers = Tickers
         self.StartDate = pd.to_datetime(StartDate)
         self.EndDate = pd.to_datetime(EndDate)
         self.Interval = Interval
 
-    def DownloadData(self):
-        # For hourly data, yfinance limits the period that can be downloaded.
-        # We define common hourly interval labels.
-        HourlyIntervals = ['60m', '1h', 'hourly']
-        if self.Interval in HourlyIntervals:
-            # If the total period exceeds 2 weeks (14 days), split into 2-week segments.
-            if (self.EndDate - self.StartDate).days > 14:
-                DataFrames = []
-                CurrentStart = self.StartDate
-                while CurrentStart < self.EndDate:
-                    CurrentEnd = CurrentStart + pd.Timedelta(days=14)
+    def _DownloadSingle(self, Ticker: str) -> pd.DataFrame:
+        """Download data for a single ticker."""
+        HourlyIntervals = ["60m", "1h", "hourly"]
+        if self.Interval in HourlyIntervals and (self.EndDate - self.StartDate).days > 14:
+            DataFrames = []
+            CurrentStart = self.StartDate
+            while CurrentStart < self.EndDate:
+                CurrentEnd = CurrentStart + pd.Timedelta(days=14)
+                if CurrentEnd > self.EndDate:
+                    CurrentEnd = self.EndDate
+                TempData = yf.download(
+                    Ticker,
+                    start=CurrentStart.strftime("%Y-%m-%d"),
+                    end=CurrentEnd.strftime("%Y-%m-%d"),
+                    interval=self.Interval,
+                    progress=False,
+                )
+                if isinstance(TempData.columns, pd.MultiIndex):
+                    TempData.columns = TempData.columns.droplevel(1)
+                DataFrames.append(TempData)
+                CurrentStart = CurrentEnd
+            FinalDf = pd.concat(DataFrames) if DataFrames else pd.DataFrame()
+        else:
+            FinalDf = yf.download(
+                Ticker,
+                start=self.StartDate.strftime("%Y-%m-%d"),
+                end=self.EndDate.strftime("%Y-%m-%d"),
+                interval=self.Interval,
+                progress=False,
+            )
+            if isinstance(FinalDf.columns, pd.MultiIndex):
+                FinalDf.columns = FinalDf.columns.droplevel(1)
 
-                    if CurrentEnd > self.EndDate:
-                        CurrentEnd = self.EndDate
-
-                    TempData = yf.download(
-                        self.Ticker,
-                        start=CurrentStart.strftime('%Y-%m-%d'),
-                        end=CurrentEnd.strftime('%Y-%m-%d'),
-                        interval=self.Interval,
-                        progress=False
-                    )
-
-                    if isinstance(TempData.columns, pd.MultiIndex):
-                        TempData.columns = TempData.columns.droplevel(1)
-
-                    DataFrames.append(TempData)
-                    CurrentStart = CurrentEnd
-
-                if DataFrames:
-                    FinalDf = pd.concat(DataFrames)
-                    return FinalDf
-                
-        # For non-hourly data or periods within the 2-week limit, download directly.
-        FinalDf = yf.download(
-            self.Ticker,
-            start=self.StartDate.strftime('%Y-%m-%d'),
-            end=self.EndDate.strftime('%Y-%m-%d'),
-            interval=self.Interval,
-            progress=False
-        )
-
-        if isinstance(FinalDf.columns, pd.MultiIndex):
-            FinalDf.columns = FinalDf.columns.droplevel(1)
-
-        FinalDf.columns.name = None 
-
+        FinalDf.columns.name = None
+        FinalDf["Ticker"] = Ticker
         return FinalDf
+
+    def DownloadData(self):
+        DataFrames = [self._DownloadSingle(T) for T in self.Tickers]
+        if DataFrames:
+            return pd.concat(DataFrames)
+        return pd.DataFrame()

--- a/Params.yaml
+++ b/Params.yaml
@@ -1,4 +1,5 @@
-Ticker: AAPL
+Tickers:
+  - AAPL
 StartDate: '2020-01-01'
 EndDate: '2023-12-31'
 Interval: 1d

--- a/UnitTests/test_data_downloader.py
+++ b/UnitTests/test_data_downloader.py
@@ -1,0 +1,31 @@
+from pathlib import Path
+from unittest.mock import patch
+import sys
+
+import pandas as pd
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from DataDownloader import YFinanceDownloader
+
+
+def test_multi_ticker_download() -> None:
+    def fake_download(ticker: str, start: str, end: str, interval: str, progress: bool) -> pd.DataFrame:
+        return pd.DataFrame(
+            {
+                "Open": [1, 2],
+                "High": [2, 3],
+                "Low": [0, 1],
+                "Close": [1, 2],
+                "Volume": [10, 10],
+            },
+            index=pd.date_range(start="2020-01-01", periods=2, freq="D"),
+        )
+
+    with patch("yfinance.download", side_effect=fake_download) as download_mock:
+        downloader = YFinanceDownloader(["AAA", "BBB"], "2020-01-01", "2020-01-05", "1d")
+        df = downloader.DownloadData()
+        assert set(df["Ticker"].unique()) == {"AAA", "BBB"}
+        assert len(df) == 4
+        assert download_mock.call_count == 2
+

--- a/main.py
+++ b/main.py
@@ -14,7 +14,7 @@ def main() -> None:
     logging.info("Loaded parameters: %s", Params)
 
     Downloader = YFinanceDownloader(
-        Params.get("Ticker", "AAPL"),
+        Params.get("Tickers", ["AAPL"]),
         Params.get("StartDate", "2023-01-01"),
         Params.get("EndDate", "2023-01-10"),
         Params.get("Interval", "1d"),


### PR DESCRIPTION
## Summary
- enhance `YFinanceDownloader` to handle multiple tickers
- update `Params.yaml` for list of tickers
- adapt `main.py` to new parameter name
- add unit test for downloader multi-ticker logic