### PR TITLE
[Triple-Barrier-Method] Use min_periods=1 for indicators

### DIFF
--- a/UnitTests/test_technical_indicator.py
+++ b/UnitTests/test_technical_indicator.py
@@ -55,3 +55,40 @@ def test_mfi_nullable_int() -> None:
     Indicator = TechnicalIndicator(NullableData, Params)
     Result = Indicator.Apply("MFI")
     assert Result["MFI_3"].dtype == float
+
+
+def test_no_initial_nans() -> None:
+    Data = pd.DataFrame(
+        {
+            "Close": list(range(1, 6)),
+            "High": [x + 1 for x in range(1, 6)],
+            "Low": [x - 1 for x in range(1, 6)],
+            "Volume": list(range(1, 6)),
+        }
+    )
+    Params = {
+        "SMAWindows": [3],
+        "EMAWindows": [3],
+        "RSIWindows": [3],
+        "BBParams": [{"Window": 3, "Std": 2}],
+        "MFIWindows": [3],
+        "MACDParams": [{"Fast": 3, "Slow": 5, "Signal": 2}],
+    }
+    Indicator = TechnicalIndicator(Data, Params)
+    Result = Indicator.ApplyAll()
+    FirstRow = Result.iloc[0]
+    Columns = [
+        "SMA_3",
+        "EMA_3",
+        "RSI_3",
+        "BBL_3_2.0",
+        "BBM_3_2.0",
+        "BBU_3_2.0",
+        "BBB_3_2.0",
+        "BBP_3_2.0",
+        "MFI_3",
+        "MACD_3_5_2",
+        "MACDh_3_5_2",
+        "MACDs_3_5_2",
+    ]
+    assert FirstRow[Columns].isna().sum() == 0


### PR DESCRIPTION
## Summary
- compute SMA, EMA, RSI, Bollinger Bands, MFI and MACD using pandas with `min_periods=1`
- ensure no NaN values due to lookback windows
- add regression test for no initial NaN values