### PR TITLE
[Triple-Barrier-Method] Convert eval labels to original scale

### DIFF
--- a/LSTMModel.py
+++ b/LSTMModel.py
@@ -179,6 +179,10 @@ class LSTMModel:
                         PredLabels.append(PredLab)
                         TrueLabels.append(Lab)
                 if TrueLabels:
-                    Report = classification_report(TrueLabels, PredLabels)
-                    logging.info("Classification report for %s:\n%s", Ticker, Report)
+                    PredLabelsOrig = [p - 1 for p in PredLabels]
+                    TrueLabelsOrig = [t - 1 for t in TrueLabels]
+                    Report = classification_report(TrueLabelsOrig, PredLabelsOrig)
+                    logging.info(
+                        "Classification report for %s:\n%s", Ticker, Report
+                    )
         return F1, ValCopy


### PR DESCRIPTION
## Summary
- convert predictions and targets back to original label scale in `Evaluate`
- assert original labels appear in classification report