### PR TITLE
[Triple-Barrier-Method] Update labeling scheme and remove LSTM label mapping

### DIFF
--- a/DataLabel.py
+++ b/DataLabel.py
@@ -62,16 +62,16 @@ class DataLabel:
 
             if TpIdx is not None and SlIdx is not None:
                 Label = (
-                    1
+                    2
                     if Slice.index.get_loc(TpIdx) <= Slice.index.get_loc(SlIdx)
-                    else -1
+                    else 0
                 )
             elif TpIdx is not None:
-                Label = 1
+                Label = 2
             elif SlIdx is not None:
-                Label = -1
-            else:
                 Label = 0
+            else:
+                Label = 1
             Labels.append(Label)
         Data["Label"] = Labels
         return Data

--- a/LSTMModel.py
+++ b/LSTMModel.py
@@ -44,7 +44,7 @@ class SequenceDataset(Dataset):
 
     def __getitem__(self, Index: int) -> Tuple[torch.Tensor, torch.Tensor]:
         X = torch.tensor(self.Samples[Index], dtype=torch.float32)
-        Label = self.Labels[Index] + 1  # map -1,0,1 -> 0,1,2
+        Label = self.Labels[Index]
         Y = torch.tensor(Label, dtype=torch.long)
         return X, Y
 
@@ -164,7 +164,7 @@ class LSTMModel:
         F1 = f1_score(Labels, Predictions, average="weighted")
         ValCopy = self.ValData.copy()
         for Idx, Pred in zip(Idxs, Predictions):
-            ValCopy.loc[Idx, "Prediction"] = Pred - 1
+            ValCopy.loc[Idx, "Prediction"] = Pred
         if "Ticker" in ValCopy.columns:
             ResultMap = {
                 Idx: (Pred, Label)
@@ -179,9 +179,7 @@ class LSTMModel:
                         PredLabels.append(PredLab)
                         TrueLabels.append(Lab)
                 if TrueLabels:
-                    PredLabelsOrig = [p - 1 for p in PredLabels]
-                    TrueLabelsOrig = [t - 1 for t in TrueLabels]
-                    Report = classification_report(TrueLabelsOrig, PredLabelsOrig)
+                    Report = classification_report(TrueLabels, PredLabels)
                     logging.info(
                         "Classification report for %s:\n%s", Ticker, Report
                     )

--- a/UnitTests/test_data_label.py
+++ b/UnitTests/test_data_label.py
@@ -19,7 +19,7 @@ def test_triple_barrier_labels() -> None:
     )
     Labeler = DataLabel(Params)
     Labeled = Labeler.Apply("TripleBarrier", Data)
-    assert list(Labeled["Label"]) == [1, 0, 0, 0, 0]
+    assert list(Labeled["Label"]) == [2, 1, 1, 1, 1]
 
 
 def test_triple_barrier_multi_ticker() -> None:
@@ -36,5 +36,5 @@ def test_triple_barrier_multi_ticker() -> None:
     Labeled = Labeler.Apply("TripleBarrier", Data)
     FirstLabels = list(Labeled[Labeled["Ticker"] == "AAA"]["Label"])
     SecondLabels = list(Labeled[Labeled["Ticker"] == "BBB"]["Label"])
-    assert FirstLabels == [1, 0, 0, 0, 0]
-    assert SecondLabels == [1, 0, 0, 0, 0]
+    assert FirstLabels == [2, 1, 1, 1, 1]
+    assert SecondLabels == [2, 1, 1, 1, 1]

--- a/UnitTests/test_lstm_model.py
+++ b/UnitTests/test_lstm_model.py
@@ -16,7 +16,7 @@ def test_lstm_training_and_evaluation(caplog: Any) -> None:
     Data = pd.DataFrame(
         {
             "Feature": list(range(10)) + list(range(10, 20)),
-            "Label": [-1, -1, 0, 1, 1] * 4,
+            "Label": [0, 0, 1, 2, 2] * 4,
             "Ticker": ["AAA"] * 10 + ["BBB"] * 10,
         }
     )
@@ -45,6 +45,6 @@ def test_lstm_training_and_evaluation(caplog: Any) -> None:
     ]
     assert Reports
     for Text in Reports:
-        assert "-1" in Text
         assert " 0" in Text
         assert " 1" in Text
+        assert " 2" in Text


### PR DESCRIPTION
## Summary
- update triple barrier labels: 0=stop loss, 1=time limit, 2=take profit
- drop mapping logic from LSTMModel
- adjust unit tests for new labels