### PR TITLE
[Triple-Barrier-Method] add caching mechanism

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ Logs/
 .idx
 .venv
 .vscode
+DataCache/
+*.pth

--- a/DataDownloader.py
+++ b/DataDownloader.py
@@ -1,17 +1,48 @@
-from typing import List
+from typing import List, Optional
+
+import logging
+from pathlib import Path
 
 import pandas as pd
 import yfinance as yf
 
 class YFinanceDownloader:
-    def __init__(self, Tickers: List[str], StartDate: str, EndDate: str, Interval: str) -> None:
+    def __init__(self, Tickers: List[str], StartDate: str, EndDate: str, Interval: str, CacheDir: str = "DataCache") -> None:
         self.Tickers = Tickers
         self.StartDate = pd.to_datetime(StartDate)
         self.EndDate = pd.to_datetime(EndDate)
         self.Interval = Interval
+        self.CacheDir = Path(CacheDir)
+        self.CacheDir.mkdir(parents=True, exist_ok=True)
+
+    def _GetCachePath(self, Ticker: str) -> Path:
+        FileName = (
+            f"{Ticker}_{self.StartDate.strftime('%Y%m%d')}_"
+            f"{self.EndDate.strftime('%Y%m%d')}_{self.Interval}.pkl"
+        )
+        return self.CacheDir / FileName
+
+    def _LoadFromCache(self, Ticker: str) -> Optional[pd.DataFrame]:
+        PathToFile = self._GetCachePath(Ticker)
+        if PathToFile.exists():
+            logging.getLogger(__name__).info("Loading %s from cache", Ticker)
+            return pd.read_pickle(PathToFile)
+        return None
+
+    def _SaveToCache(self, Ticker: str, Data: pd.DataFrame) -> None:
+        PathToFile = self._GetCachePath(Ticker)
+        try:
+            Data.to_pickle(PathToFile)
+        except Exception as Err:  # pragma: no cover
+            logging.getLogger(__name__).warning("Failed to cache %s: %s", Ticker, Err)
 
     def _DownloadSingle(self, Ticker: str) -> pd.DataFrame:
         """Download data for a single ticker."""
+        Cached = self._LoadFromCache(Ticker)
+        if Cached is not None:
+            Cached["Ticker"] = Ticker
+            return Cached
+
         HourlyIntervals = ["60m", "1h", "hourly"]
         if self.Interval in HourlyIntervals and (self.EndDate - self.StartDate).days > 14:
             DataFrames = []
@@ -45,6 +76,7 @@ class YFinanceDownloader:
 
         FinalDf.columns.name = None
         FinalDf["Ticker"] = Ticker
+        self._SaveToCache(Ticker, FinalDf)
         return FinalDf
 
     def DownloadData(self):

--- a/UnitTests/test_data_downloader.py
+++ b/UnitTests/test_data_downloader.py
@@ -29,3 +29,27 @@ def test_multi_ticker_download() -> None:
         assert len(df) == 4
         assert download_mock.call_count == 2
 
+
+def test_cache_usage(tmp_path: Path) -> None:
+    def fake_download(ticker: str, start: str, end: str, interval: str, progress: bool) -> pd.DataFrame:
+        return pd.DataFrame(
+            {
+                "Open": [1],
+                "High": [1],
+                "Low": [1],
+                "Close": [1],
+                "Volume": [1],
+            },
+            index=pd.date_range(start="2020-01-01", periods=1, freq="D"),
+        )
+
+    with patch("yfinance.download", side_effect=fake_download) as download_mock:
+        downloader = YFinanceDownloader(["AAA"], "2020-01-01", "2020-01-02", "1d", CacheDir=str(tmp_path))
+        df1 = downloader.DownloadData()
+        assert download_mock.call_count == 1
+
+        downloader2 = YFinanceDownloader(["AAA"], "2020-01-01", "2020-01-02", "1d", CacheDir=str(tmp_path))
+        df2 = downloader2.DownloadData()
+        assert download_mock.call_count == 1
+        pd.testing.assert_frame_equal(df1.reset_index(drop=True), df2.reset_index(drop=True))
+

--- a/main.py
+++ b/main.py
@@ -20,6 +20,7 @@ def main() -> None:
         Params.get("StartDate", "2023-01-01"),
         Params.get("EndDate", "2023-01-10"),
         Params.get("Interval", "1d"),
+        Params.get("CacheDir", "DataCache"),
     )
 
     Data = Downloader.DownloadData()


### PR DESCRIPTION
## Summary
- implement cache support in `DataDownloader` for previously downloaded data
- ensure downloaded CSVs are ignored in `.gitignore`
- update `main.py` to set cache directory
- test new caching behavior