### PR TITLE
[Triple-Barrier-Method] add per ticker zscore normalization

### DIFF
--- a/Params.yaml
+++ b/Params.yaml
@@ -32,3 +32,4 @@ LSTMParams:
   Epochs: 1
   HiddenSize: [16]
   ModelPath: LSTMModel.pth
+ScalerDictPath: ScalerDict.pkl

--- a/UnitTests/test_per_ticker_z_score.py
+++ b/UnitTests/test_per_ticker_z_score.py
@@ -1,0 +1,31 @@
+from pathlib import Path
+import sys
+import pandas as pd
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from TechnicalIndicator import TechnicalIndicator
+
+
+def test_per_ticker_z_score() -> None:
+    df = pd.DataFrame({
+        "Value": [1, 2, 3, 4],
+        "Ticker": ["AAA", "AAA", "BBB", "BBB"],
+        "Label": [0, 0, 0, 0],
+        "Shares": [1, 1, 1, 1],
+    })
+    result, scalers = TechnicalIndicator.PerTickerZScore(df)
+    assert pytest.approx(result.loc[0, "Value"]) == -1.0
+    assert pytest.approx(result.loc[1, "Value"]) == 1.0
+    assert set(scalers.keys()) == {"AAA", "BBB"}
+
+    new_df = pd.DataFrame({
+        "Value": [5, 6],
+        "Ticker": ["AAA", "BBB"],
+        "Label": [0, 0],
+        "Shares": [1, 1],
+    })
+    transformed, _ = TechnicalIndicator.PerTickerZScore(new_df, scalers)
+    assert pytest.approx(transformed.loc[0, "Value"]) == (5 - 1.5) / 0.5
+    assert pytest.approx(transformed.loc[1, "Value"]) == (6 - 3.5) / 0.5


### PR DESCRIPTION
## Summary
- implement per-ticker z-score normalization utility
- store scaler parameters and add setting to Params.yaml
- normalize train and validation datasets in `main.py`
- cover normalization in unit tests