### PR TITLE
[Triple-Barrier-Method] cast numeric cols to float

### DIFF
--- a/TechnicalIndicator.py
+++ b/TechnicalIndicator.py
@@ -12,6 +12,13 @@ class TechnicalIndicator:
 
     def __init__(self, Data: pd.DataFrame, Params: Dict[str, Any]) -> None:
         self.Data = Data.copy()
+        NumericCols = [
+            Col
+            for Col in ["Close", "High", "Low", "Open", "Volume"]
+            if Col in self.Data.columns
+        ]
+        if NumericCols:
+            self.Data[NumericCols] = self.Data[NumericCols].astype(float)
         self.Params = Params
         self.Methods: Dict[str, Callable[[], pd.DataFrame]] = {}
         self.RegisterIndicator("MACD", self._AddMacd)

--- a/UnitTests/test_technical_indicator.py
+++ b/UnitTests/test_technical_indicator.py
@@ -92,3 +92,19 @@ def test_no_initial_nans() -> None:
         "MACDs_3_5_2",
     ]
     assert FirstRow[Columns].isna().sum() == 0
+
+
+def test_numeric_columns_cast_to_float() -> None:
+    Data = pd.DataFrame(
+        {
+            "Close": pd.Series([1, 2], dtype="Int64"),
+            "High": pd.Series([2, 3], dtype="Int64"),
+            "Low": pd.Series([0, 1], dtype="Int64"),
+            "Volume": pd.Series([10, 20], dtype="Int64"),
+        }
+    )
+    Params = {"EMAWindows": [2]}
+    Indicator = TechnicalIndicator(Data, Params)
+    Result = Indicator.Apply("EMA")
+    for Col in ["Close", "High", "Low", "Volume"]:
+        assert Result[Col].dtype == float


### PR DESCRIPTION
## Summary
- sanitize numeric columns in `TechnicalIndicator` to avoid dtype warnings
- add unit test ensuring numeric columns are cast to float