### PR TITLE
[TripleBarrierMethod] enable gpu support in lstm model

### DIFF
--- a/UnitTests/test_lstm_model.py
+++ b/UnitTests/test_lstm_model.py
@@ -6,6 +6,7 @@ import logging
 from typing import Any
 
 import pandas as pd
+import torch
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
@@ -84,3 +85,17 @@ def test_classification_report_includes_all_labels(caplog: Any) -> None:
         assert " 0" in Text
         assert " 1" in Text
         assert " 2" in Text
+
+
+def test_model_device_selection() -> None:
+    Data = pd.DataFrame({"Feature": [0, 1, 2, 3], "Label": [0, 1, 0, 1]})
+    Params = {
+        "BatchSize": 1,
+        "LearningRate": 0.01,
+        "Epochs": 1,
+        "SequenceLength": 2,
+        "HiddenSize": [2],
+    }
+    Model = LSTMModel(Data, Data, ["Feature"], "Label", Params)
+    Expected = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    assert Model.Device == Expected

--- a/main.py
+++ b/main.py
@@ -64,6 +64,7 @@ def main() -> None:
             pickle.dump(Scalers, File)
     ValDf, _ = TechnicalIndicator.PerTickerZScore(ValDf, Scalers)
     Model = LSTMModel(TrainDf, ValDf, Features, LabelColumn, LstmParams)
+    logging.info("Using device: %s", Model.Device)
     Model.Train()
     Model.SaveModel(LstmParams.get("ModelPath"))
     F1, PredDf = Model.Evaluate()


### PR DESCRIPTION
## Summary
- add device selection in `LSTMModel` so it trains on GPU when available
- log which device is used from `main.py`
- test device selection in the LSTM unit tests