### PR TITLE
[Triple-Barrier-Method] Add class-weighted loss

### DIFF
--- a/main.py
+++ b/main.py
@@ -64,6 +64,7 @@ def main() -> None:
             pickle.dump(Scalers, File)
     ValDf, _ = TechnicalIndicator.PerTickerZScore(ValDf, Scalers)
     Model = LSTMModel(TrainDf, ValDf, Features, LabelColumn, LstmParams)
+    logging.info("Class weights: %s", Model.ClassWeights.cpu().tolist())
     logging.info("Using device: %s", Model.Device)
     Model.Train()
     Model.SaveModel(LstmParams.get("ModelPath"))


### PR DESCRIPTION
## Summary
- weight CrossEntropyLoss by inverse class frequency in `LSTMModel`
- log class weights when creating model
- test that class weights are computed correctly